### PR TITLE
Miscellaneous functions, to be reviewed. #22

### DIFF
--- a/Sources/Query/MiscFuntions.swift
+++ b/Sources/Query/MiscFuntions.swift
@@ -8,6 +8,25 @@
 
 import Foundation
 
+
+public let NextId = Next_Id()
+
+public struct Next_Id: Expr {
+    
+    let sharedInstance = Next_Id()
+    
+    public init(){}
+    
+}
+
+extension Next_Id: Encodable {
+    
+    public func toJSON() -> AnyObject {
+        return ["next_id": NSNull() ]
+    }
+}
+
+
 /**
  *  `Equals` tests equivalence between a list of values.
  *


### PR DESCRIPTION
This pull request contains [Fauna Miscellaneous functions](https://faunadb.com/documentation/queries#misc_functions)
@erickpintor  Could you take a look at this?

I wanted to check:
- if the serialization is correct.
- if the function name (initializer named parameters) for each function are correct.
- if there is something wring or missing.

Here you have  are some test i wrote but the pull request doesn't include. 

``` swift
func testMiscellaneousFunctions(){

        let equals = Equals(terms: 2, 2, Var("v_2"))
        XCTAssertEqual(equals.jsonString, "{\"equals\":[2,2,{\"var\":\"v_2\"}]}")

        let equals2 = Equals(terms: Match(indexRef: "indexes/spells_by_element", terms: "fire"))
        XCTAssertEqual(equals2.jsonString, "{\"equals\":{\"terms\":\"fire\",\"match\":{\"@ref\":\"indexes\\/spells_by_element\"}}}")

        let contains = Contains(path: "favorites", "foods", inExpr:  ["favorites":
            ["foods":
                ["crunchings",
                    "munchings",
                    "lunchings"] as Arr
                ] as Obj
            ] as Obj)

        XCTAssertEqual(contains.jsonString, "{\"contains\":[\"favorites\",\"foods\"],\"in\":{\"object\":{\"favorites\":{\"object\":{\"foods\":[\"crunchings\",\"munchings\",\"lunchings\"]}}}}}")


        let contains2 = Contains(path: "favorites", inExpr:  ["favorites":
            ["foods":
                ["crunchings",
                    "munchings",
                    "lunchings"] as Arr
                ] as Obj
            ] as Obj)

        XCTAssertEqual(contains2.jsonString, "{\"contains\":\"favorites\",\"in\":{\"object\":{\"favorites\":{\"object\":{\"foods\":[\"crunchings\",\"munchings\",\"lunchings\"]}}}}}")
    }
```
