### PR TITLE
Set-Functions #17

### DIFF
--- a/Sources/Query/FunctionType.swift
+++ b/Sources/Query/FunctionType.swift
@@ -10,4 +10,3 @@ import Foundation
 
 public protocol FunctionType: Expr {}
 
-public protocol LambdaFunctionType: FunctionType {}

--- a/Sources/Query/Language.swift
+++ b/Sources/Query/Language.swift
@@ -87,7 +87,7 @@ extension Var: StringLiteralConvertible {
  //                Arr(Arr("Hen", "Wen"))))
  
  */
-public struct Map: LambdaFunctionType{
+public struct Map: FunctionType{
     let lambda: Lambda
     let collection: Arr
     
@@ -129,7 +129,7 @@ extension Map: Encodable {
  Expr(ObjectV("foreach" -> lambda.value, "collection" -> collection.value))
 
  */
-public struct Foreach: LambdaFunctionType {
+public struct Foreach: FunctionType {
     let lambda: Lambda
     let collection: Arr
     

--- a/Sources/Query/SetFunctions.swift
+++ b/Sources/Query/SetFunctions.swift
@@ -25,22 +25,36 @@ public struct Match: FunctionType {
      
      - returns: a Match expression.
      */
-    public init(indexRef: Ref, terms: Expr...){
-        self.indexRef = indexRef
+    public init(index: Ref, terms: Expr...){
+        self.indexRef = index
         self.terms = terms
     }
     
-    public init(indexRefExpr: Expr, terms: Expr...){
+    public init(index: Ref){
+        self.indexRef = index
+        self.terms = []
+    }
+    
+    
+    public init(_ indexRefExpr: Expr, terms: Expr...){
         self.indexRef = indexRefExpr
         self.terms = terms
+    }
+    
+    public init(_ indexRefExpr: Expr){
+        self.indexRef = indexRefExpr
+        self.terms = []
     }
 }
 
 extension Match: Encodable {
     
     public func toJSON() -> AnyObject {
-        return [ "match": indexRef.toJSON(),
-                 "terms":  terms.varArgsToAnyObject ]
+        if terms > 0 {
+            return [ "match": indexRef.toJSON(),
+                     "terms":  terms.varArgsToAnyObject ]
+        }
+        return [ "match": indexRef.toJSON()]
     }
 }
 
@@ -113,7 +127,6 @@ extension Intersection: Encodable {
  */
 public struct Difference: FunctionType {
     
-    let source: Expr
     let sets: [Expr]
     
     /**
@@ -125,8 +138,9 @@ public struct Difference: FunctionType {
      - returns: An Difference expression.
      */
     public init(source: Expr, sets: Expr...){
-        self.source = source
-        self.sets = sets
+        var sourceC = [source]
+        sourceC.appendContentsOf(sets)
+        self.sets = sourceC
     }
     
 }
@@ -134,9 +148,7 @@ public struct Difference: FunctionType {
 extension Difference: Encodable {
     
     public func toJSON() -> AnyObject {
-        var array = [source]
-        array.appendContentsOf(sets)
-        return ["difference" : array.varArgsToAnyObject]
+        return ["difference" : sets.varArgsToAnyObject]
     }
 }
 


### PR DESCRIPTION
This pull request includes all [set functions](https://faunadb.com/documentation/queries#sets).

@erickpintor Could you please review this as well? 

These are the test covering the functionality.

``` swift
    func testSets(){

        //MARK: Match

        let matchSet = Match(indexRef: "indexes/spells_by_elements",
                                terms: "fire")
        XCTAssertEqual(matchSet.jsonString, "{\"terms\":\"fire\",\"match\":{\"@ref\":\"indexes\\/spells_by_elements\"}}")

        //MARK: Union

        let union = Union(sets: Match(indexRef: "indexes/spells_by_element", terms: "fire"),
                                Match(indexRef: "indexes/spells_by_element", terms: "water"))
        XCTAssertEqual(union.jsonString, "{\"union\":[{\"terms\":\"fire\",\"match\":{\"@ref\":\"indexes\\/spells_by_element\"}},{\"terms\":\"water\",\"match\":{\"@ref\":\"indexes\\/spells_by_element\"}}]}")

        //MARK: Intersection

        let intersection = Intersection(sets: Match(indexRef: "indexes/spells_by_element", terms: "fire"),
                                              Match(indexRef: "indexes/spells_by_element", terms: "water"))
        XCTAssertEqual(intersection.jsonString, "{\"intersection\":[{\"terms\":\"fire\",\"match\":{\"@ref\":\"indexes\\/spells_by_element\"}},{\"terms\":\"water\",\"match\":{\"@ref\":\"indexes\\/spells_by_element\"}}]}")

        //MARK: Difference

        let difference = Difference(source: Match(indexRef: "indexes/spells_by_element", terms: "fire"),
                                      sets: Match(indexRef: "indexes/spells_by_element", terms: "water"))
        XCTAssertEqual(difference.jsonString, "{\"difference\":[{\"terms\":\"fire\",\"match\":{\"@ref\":\"indexes\\/spells_by_element\"}},{\"terms\":\"water\",\"match\":{\"@ref\":\"indexes\\/spells_by_element\"}}]}")

        //MARK: Join

        let join = Join(sourceSet: Match(indexRef: Ref("indexes/spells_by_element"),
                                            terms: "fire"),
                        with: Lambda(){
                                    Get(refExpr: $0)
                        })
        XCTAssertEqual(join.jsonString, "{\"with\":{\"expr\":{\"get\":{\"var\":\"v_2\"}},\"lambda\":\"v_2\"},\"join\":{\"terms\":\"fire\",\"match\":{\"@ref\":\"indexes\\/spells_by_element\"}}}")

    }
```
