### PR TITLE
Discarding results of map functions at QueryResult

### DIFF
--- a/Sources/FaunaDB/QueryResult.swift
+++ b/Sources/FaunaDB/QueryResult.swift
@@ -40,7 +40,6 @@ public class QueryResult<T> {
 
 extension QueryResult {
 
-    @discardableResult
     public func map<A>(at queue: DispatchQueue? = nil, _ fn: @escaping (T) throws -> A) -> QueryResult<A> {
         let res = QueryResult<A>()
 
@@ -51,7 +50,6 @@ extension QueryResult {
         return res
     }
 
-    @discardableResult
     public func flatMap<A>(at queue: DispatchQueue? = nil, _ fn: @escaping (T) throws -> QueryResult<A>) -> QueryResult<A> {
         let res = QueryResult<A>()
 
@@ -72,7 +70,6 @@ extension QueryResult {
 
 extension QueryResult {
 
-    @discardableResult
     public func mapErr(at queue: DispatchQueue? = nil, _ fn: @escaping (Error) throws -> T) -> QueryResult {
         let res = QueryResult()
 
@@ -83,7 +80,6 @@ extension QueryResult {
         return res
     }
 
-    @discardableResult
     public func flatMapErr(at queue: DispatchQueue? = nil, _ fn: @escaping (Error) throws -> QueryResult) -> QueryResult {
         let res = QueryResult()
 
@@ -96,6 +92,26 @@ extension QueryResult {
         }
 
         return res
+    }
+
+}
+
+extension QueryResult {
+
+    @discardableResult
+    public func onSuccess(at queue: DispatchQueue? = nil, _ callback: @escaping (T) throws -> Void) -> QueryResult {
+        return map(at: queue) { res in
+            try callback(res)
+            return res
+        }
+    }
+
+    @discardableResult
+    public func onFailure(at queue: DispatchQueue? = nil, _ callback: @escaping (Error) throws -> Void) -> QueryResult {
+        return mapErr(at: queue) { error in
+            try callback(error)
+            throw error
+        }
     }
 
 }

--- a/Tests/FaunaDBTests/QueryResultTests.swift
+++ b/Tests/FaunaDBTests/QueryResultTests.swift
@@ -41,6 +41,44 @@ class QueryResultTests: XCTestCase {
 
     }
 
+    func testOnSuccess() {
+        var called = 0
+
+        try! successfulQueryResult(value: 1).onSuccess { called += $0 }.await()
+        try! successfulQueryResult(value: 1).onSuccess(at: queue) { called += $0 }.await()
+
+        XCTAssertEqual(called, 2)
+    }
+
+    func testOnFailure() {
+        var called = 0
+
+        _ = try? failedQueryResult().onFailure { _ in called += 1 }.await()
+        _ = try? failedQueryResult().onFailure(at: queue) { _ in called += 1 }.await()
+
+        XCTAssertEqual(called, 2)
+    }
+
+    func testCanCallOnSucessMoreThanOnce() {
+        var called = 0
+
+        successfulQueryResult(value: 1)
+            .onSuccess { called += $0 }
+            .onSuccess { called += $0 }
+
+        XCTAssertEqual(called, 2)
+    }
+
+    func testCanCallOnFailureMoreThanOnce() {
+        var called = 0
+
+        failedQueryResult()
+            .onFailure { _ in called += 1 }
+            .onFailure { _ in called += 1 }
+
+        XCTAssertEqual(called, 2)
+    }
+
     func testDoNotExecuteCallbacksIfNilValue() {
         let res = QueryResult<Int>()
         _ = res.map { _ in XCTFail("Should not map nil value") }


### PR DESCRIPTION
Closes: https://github.com/faunadb/sales-engineering/issues/444

It seems odd at first but, while developing the Example project I quickly realize that most of the time you're not interested on the actual result but rather to react upon it's completion.

For example:

```swift
        Post.save(postToSave).map(at: .main) { [weak self] savedPost in
            self?.post = savedPost
            self?.goBackToPreviousView()
        }
```

The alternative would be to call `await`, which blocks the thread preventing the user to cancel the action, if needed.