### PR TITLE
Update driver info

### DIFF
--- a/Example/README.md
+++ b/Example/README.md
@@ -21,11 +21,11 @@ This demo is a simple blog post manager. It has a basic model called `Post`,
 instances of which must have a title and may optionally have a body.
 
 Most of the interaction with FaunaDB is located in the
-[Posts.swift](https://github.com/faunadb/faunadb-swift/blob/master/Example/Example/Post.swift)
+[Posts.swift](https://github.com/fauna/faunadb-swift/blob/master/Example/Example/Post.swift)
 file. It contains the base model `Post` as well as the code needed to store,
 update, delete, and show posts saved at FaunaDB.
 
-[Database.swift](https://github.com/faunadb/faunadb-swift/blob/master/Example/Example/Database.swift)
+[Database.swift](https://github.com/fauna/faunadb-swift/blob/master/Example/Example/Database.swift)
 contains the database setup for this demo. In a real life application, that code
 would live somewhere else, such as a separated provisioning script. For the
 purpose of this example it is easier to let the application setup the database
@@ -36,4 +36,4 @@ create, update, delete, and show the blog posts.
 
 ## Demo
 
-![](https://github.com/faunadb/faunadb-swift/blob/master/Example/demo.gif)
+![](https://github.com/fauna/faunadb-swift/blob/master/Example/demo.gif)

--- a/FaunaDB.podspec
+++ b/FaunaDB.podspec
@@ -2,10 +2,10 @@ Pod::Spec.new do |s|
   s.name             = "FaunaDB"
   s.version          = "0.2.0-SNAPSHOT"
   s.summary          = "Swift driver for FaunaDB."
-  s.homepage         = "https://github.com/faunadb/faunadb-swift"
+  s.homepage         = "https://github.com/fauna/faunadb-swift"
   s.author           = { "Fauna, Inc" => "priority@fauna.com" }
   s.license          = { type: 'Mozilla Public License 2.0', file: 'LICENSE' }
-  s.source           = { git: "https://github.com/faunadb/faunadb-swift.git", tag: s.version.to_s }
+  s.source           = { git: "https://github.com/fauna/faunadb-swift.git", tag: s.version.to_s }
   s.social_media_url = 'https://twitter.com/faunadb'
   s.source_files     = 'Sources/**/*.swift'
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016 Fauna, Inc.
+Copyright 2017 Fauna, Inc.
 
 Licensed under the Mozilla Public License, Version 2.0 (the "License"); you may
 not use this software except in compliance with the License. You may obtain a

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # FaunaDB Swift Driver
 
 [![CocoaPods](https://img.shields.io/cocoapods/v/FaunaDB.svg)](http://cocoapods.org/pods/FaunaDB)
-[![Build Status](https://travis-ci.org/faunadb/faunadb-swift.svg?branch=master)](https://travis-ci.org/faunadb/faunadb-swift)
-[![Coverage Status](https://codecov.io/gh/faunadb/faunadb-swift/branch/master/graph/badge.svg)](https://codecov.io/gh/faunadb/faunadb-swift)
-[![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/faunadb/faunadb-swift/master/LICENSE)
+[![Build Status](https://travis-ci.org/fauna/faunadb-swift.svg?branch=master)](https://travis-ci.org/fauna/faunadb-swift)
+[![Coverage Status](https://codecov.io/gh/fauna/faunadb-swift/branch/master/graph/badge.svg)](https://codecov.io/gh/fauna/faunadb-swift)
+[![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/fauna/faunadb-swift/master/LICENSE)
 
 A Swift driver for [FaunaDB](https://fauna.com)
 
@@ -15,10 +15,10 @@ A Swift driver for [FaunaDB](https://fauna.com)
 
 ## Documentation
 
-Check out the Swift-specific [reference documentation](http://faunadb.github.io/faunadb-swift/).
+Check out the Swift-specific [reference documentation](http://fauna.github.io/faunadb-swift/).
 
 You can find more information in the FaunaDB [documentation](https://fauna.com/documentation)
-and in our [example project](https://github.com/faunadb/faunadb-swift/tree/master/Example).
+and in our [example project](https://github.com/fauna/faunadb-swift/tree/master/Example).
 
 ## Using the Driver
 
@@ -33,14 +33,14 @@ pod 'FaunaDB', '~> 0.1'
 Carthage:
 
 ```
-github 'faunadb/faunadb-swift'
+github 'fauna/faunadb-swift'
 ```
 
 SwiftPM:
 
 ```swift
 .Package(
-    url: "https://github.com/faunadb/faunadb-swift.git",
+    url: "https://github.com/fauna/faunadb-swift.git",
     majorVersion: 0,
     minorVersion: 1
 )
@@ -91,7 +91,7 @@ let post: Post = try! getPost.map { dbEntry in dbEntry.get("data") }
 ```
 
 For more examples, check our online [documentation](https://fauna.com/documentation)
-and our [example project](https://github.com/faunadb/faunadb-swift/tree/master/Example).
+and our [example project](https://github.com/fauna/faunadb-swift/tree/master/Example).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ FAUNA_ROOT_KEY=your-keys-secret-here swift test
 
 ## LICENSE
 
-Copyright 2016 [Fauna, Inc.](https://fauna.com/)
+Copyright 2017 [Fauna, Inc.](https://fauna.com/)
 
 Licensed under the Mozilla Public License, Version 2.0 (the
 "License"); you may not use this software except in compliance with


### PR DESCRIPTION
Bumps copyright date and updates github links for the org change.

Part of https://github.com/fauna/sales-engineering/issues/525.