### PR TITLE
Minor: removing warnings from swiftlint

### DIFF
--- a/Sources/FaunaDB/Latch.swift
+++ b/Sources/FaunaDB/Latch.swift
@@ -32,7 +32,7 @@ extension Latch {
 
     static func await(timeout: DispatchTime, _ fn: (@escaping (Try<T>) -> Void) -> Void) throws -> T {
         let latch = Latch<T>()
-        fn() { value in latch.value = value }
+        fn { value in latch.value = value }
         return try latch.await(timeout: timeout)
     }
 

--- a/Sources/FaunaDB/Query.swift
+++ b/Sources/FaunaDB/Query.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable file_length
+// swiftlint:disable file_length large_tuple
 import Foundation
 
 // MARK: Values
@@ -663,8 +663,8 @@ public struct Delete: Fn {
 ///
 /// [Reference](https://fauna.com/documentation/queries#write_functions)
 public enum Action: String {
-    case create = "create"
-    case delete = "delete"
+    case create
+    case delete
 }
 
 extension Action: Expr, AsJson {
@@ -1018,10 +1018,10 @@ public struct Time: Fn {
 
 /// Represents a time unit to be used for `Epoch` function
 public enum TimeUnit: String {
-    case second = "second"
-    case millisecond = "millisecond"
-    case microsecond = "microsecond"
-    case nanosecond = "nanosecond"
+    case second
+    case millisecond
+    case microsecond
+    case nanosecond
 }
 
 extension TimeUnit: Expr, AsJson {

--- a/Sources/FaunaDB/Value.swift
+++ b/Sources/FaunaDB/Value.swift
@@ -326,7 +326,7 @@ public struct BytesV: ScalarValue, AsJson {
 }
 
 extension BytesV: Equatable {
-    public static func ==(lhs: BytesV, rhs: BytesV) -> Bool {
+    public static func == (lhs: BytesV, rhs: BytesV) -> Bool {
         return lhs.value == rhs.value
     }
 }


### PR DESCRIPTION
Just cleaning up some warnings after I updated `swiftlint`.